### PR TITLE
Enhancements and Optimisations

### DIFF
--- a/adutils/src/main/java/com/appyhigh/adutils/AdUtilConstants.kt
+++ b/adutils/src/main/java/com/appyhigh/adutils/AdUtilConstants.kt
@@ -1,7 +1,5 @@
 package com.appyhigh.adutils
 
-import android.widget.LinearLayout
-
 object AdUtilConstants {
 
     enum class BannerAdSize {
@@ -10,7 +8,7 @@ object AdUtilConstants {
         MEDIUM_RECTANGLE
     }
 
-    val bannerAdLifeCycleHashMap = HashMap<LinearLayout, BannerAdItem>()
-    val nativeAdLifeCycleHashMap = HashMap<LinearLayout, NativeAdItem>()
+    val bannerAdLifeCycleHashMap = HashMap<Long, BannerAdItem>()
+    val nativeAdLifeCycleHashMap = HashMap<Long, NativeAdItem>()
 
 }

--- a/adutils/src/main/java/com/appyhigh/adutils/AppOpenAdCallback.kt
+++ b/adutils/src/main/java/com/appyhigh/adutils/AppOpenAdCallback.kt
@@ -1,7 +1,12 @@
 package com.appyhigh.adutils
 
-interface AppOpenAdCallback {
-    fun onInitSuccess(manager: AppOpenManager)
-    fun onAdLoaded()
-    fun onAdClosed()
+import com.google.android.gms.ads.AdError
+import com.google.android.gms.ads.LoadAdError
+
+abstract class AppOpenAdCallback {
+    open fun onInitSuccess(manager: AppOpenManager) {}
+    open fun onAdLoaded() {}
+    open fun onAdFailedToLoad(loadAdError: LoadAdError) {}
+    open fun onAdFailedToShow(adError: AdError) {}
+    open fun onAdClosed() {}
 }

--- a/adutils/src/main/java/com/appyhigh/adutils/BannerAdItem.kt
+++ b/adutils/src/main/java/com/appyhigh/adutils/BannerAdItem.kt
@@ -1,10 +1,13 @@
 package com.appyhigh.adutils
 
+import android.view.ViewGroup
 import androidx.lifecycle.Lifecycle
 import com.google.android.gms.ads.AdSize
 
 data class BannerAdItem(
+    val id: Long,
     val lifecycle: Lifecycle,
+    val viewGroup: ViewGroup,
     val adUnit: String,
     val adSize: AdSize,
     val bannerAdLoadCallback: BannerAdLoadCallback?

--- a/adutils/src/main/java/com/appyhigh/adutils/NativeAdItem.kt
+++ b/adutils/src/main/java/com/appyhigh/adutils/NativeAdItem.kt
@@ -1,11 +1,17 @@
 package com.appyhigh.adutils
 
+import android.view.ViewGroup
 import androidx.lifecycle.Lifecycle
 import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.nativead.NativeAd
+import com.google.android.gms.ads.nativead.NativeAdView
 
 data class NativeAdItem(
+    val id: Long,
     val lifecycle: Lifecycle,
     val adUnit: String,
+    val viewGroup: ViewGroup,
     val nativeAdLoadCallback: NativeAdLoadCallback?,
-    val layoutId:Int
+    val layoutId:Int,
+    val populator: ((nativeAd: NativeAd, adView: NativeAdView) -> Unit)? = null
 )

--- a/adutils/src/main/java/com/appyhigh/adutils/NativeAdLoadCallback.kt
+++ b/adutils/src/main/java/com/appyhigh/adutils/NativeAdLoadCallback.kt
@@ -1,7 +1,9 @@
 package com.appyhigh.adutils
 
-interface NativeAdLoadCallback {
-    fun onAdLoaded()
-    fun onAdFailed()
-    fun onAdClicked()
+import com.google.android.gms.ads.LoadAdError
+
+abstract class NativeAdLoadCallback {
+    open fun onAdLoaded() {}
+    open fun onAdFailed(adError: LoadAdError) {}
+    open fun onAdClicked() {}
 }

--- a/app/src/main/java/com/appyhigh/adutils/BannerAdActivity.kt
+++ b/app/src/main/java/com/appyhigh/adutils/BannerAdActivity.kt
@@ -14,7 +14,7 @@ class BannerAdActivity : AppCompatActivity() {
         binding = ActivityBannerAdBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        AdSdk().loadBannerAd(
+        AdSdk.loadBannerAd(
             lifecycle,
             binding.typeOne,
             bannerAdUnit,
@@ -22,7 +22,7 @@ class BannerAdActivity : AppCompatActivity() {
             bannerAdLoadCallback
         )
 
-        AdSdk().loadBannerAd(
+        AdSdk.loadBannerAd(
             lifecycle,
             binding.typeTwo,
             bannerAdUnit,
@@ -30,7 +30,7 @@ class BannerAdActivity : AppCompatActivity() {
             bannerAdLoadCallback
         )
 
-        AdSdk().loadBannerAd(
+        AdSdk.loadBannerAd(
             lifecycle,
             binding.typeThree,
             bannerAdUnit,

--- a/app/src/main/java/com/appyhigh/adutils/MainActivity.kt
+++ b/app/src/main/java/com/appyhigh/adutils/MainActivity.kt
@@ -88,14 +88,14 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadInterstitialAd() {
-        AdSdk().loadInterstitialAd(
+        AdSdk.loadInterstitialAd(
             "ca-app-pub-3940256099942544/1033173712",
             mInterstitialAdUtilCallback
         )
     }
 
     private fun loadRewardedAd() {
-        AdSdk().loadRewardedAd(
+        AdSdk.loadRewardedAd(
             "ca-app-pub-3940256099942544/5224354917",
             mRewardedAdUtilCallback
         )

--- a/app/src/main/java/com/appyhigh/adutils/NativeAdActivity.kt
+++ b/app/src/main/java/com/appyhigh/adutils/NativeAdActivity.kt
@@ -3,8 +3,8 @@ package com.appyhigh.adutils
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
-import com.appyhigh.adutils.databinding.ActivityBannerAdBinding
 import com.appyhigh.adutils.databinding.ActivityNativeAdBinding
+import com.google.android.gms.ads.LoadAdError
 
 class NativeAdActivity : AppCompatActivity() {
     lateinit var binding: ActivityNativeAdBinding
@@ -12,7 +12,7 @@ class NativeAdActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityNativeAdBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        AdSdk().loadNativeAd(
+        AdSdk.loadNativeAd(
             lifecycle,
             "ca-app-pub-3940256099942544/2247696110",
             binding.llRoot,
@@ -21,12 +21,12 @@ class NativeAdActivity : AppCompatActivity() {
         )
     }
 
-    private val nativeAdCallBack = object : NativeAdLoadCallback {
+    private val nativeAdCallBack = object : NativeAdLoadCallback() {
         override fun onAdLoaded() {
             Log.d("NativeAdLoadCallback", "onAdLoaded")
         }
 
-        override fun onAdFailed() {
+        override fun onAdFailed(adError: LoadAdError) {
             Log.d("NativeAdLoadCallback", "onAdFailed")
         }
 

--- a/app/src/main/java/com/appyhigh/adutils/SplashActivity.kt
+++ b/app/src/main/java/com/appyhigh/adutils/SplashActivity.kt
@@ -15,7 +15,7 @@ class SplashActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivitySplashBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        AdSdk().initialize(
+        AdSdk.initialize(
             applicationContext as MyApp,
             "ca-app-pub-3940256099942544/3419835294",
             appOpenAdCallback,
@@ -29,7 +29,7 @@ class SplashActivity : AppCompatActivity() {
         }, 4000)
     }
 
-    private val appOpenAdCallback = object : AppOpenAdCallback {
+    private val appOpenAdCallback = object : AppOpenAdCallback() {
         override fun onInitSuccess(manager: AppOpenManager) {
             appOpenManager = manager
         }


### PR DESCRIPTION
- Made AdSdk Singleton
- Added option to display AppOpenAds only once or repeatedly when app is resumed after 30 seconds
- Can now pass custom population methods to loadNativeAd() which will be called to populate the Ad data in views
- No longer need to override all methods of Callback interfaces, just override the ones needed
- Banner Ad and Native Ad Objects will be removed from memory as soon as the related Activity is destroyed
- AppOpenManager will no longer remain registered as an Observer in case AppOpenAd is to be displayed only once